### PR TITLE
[formule DU] correction erreur

### DIFF
--- a/content/files/licence_g1.txt
+++ b/content/files/licence_g1.txt
@@ -1,8 +1,8 @@
-Licence Ğ1 - v0.2
-=================
+Licence Ğ1 - v0.2.1
+===================
 
 :date: 2017-04-04 12:59
-:modified: 2017-04-04 12:59
+:modified: 2017-05-11 19:10
 
 **Licence de la monnaie et engagement de responsabilité.**
 
@@ -17,7 +17,7 @@ Monnaie Ğ1
 
 Le montant du DU est identique chaque jour jusqu'au prochain équinoxe, où le DU sera alors réévalué selon la formule :
 
-* DUjour(équinoxe suivant) = DUjour(équinoxe) + c² (M/N)(équinoxe) / (15778800 secondes)
+* DUjour(équinoxe suivant) = DUjour(équinoxe) + c² (M/N)(équinoxe) / (182,625 jours)
 
 Avec comme paramètres :
 


### PR DESCRIPTION
Dans le code de duniter, le programme divise par (dtReeval / dt) et non pas par dtReeval comme écrit sur la version à.2 de la présente licence. La preuve ici : https://github.com/duniter/duniter/blob/master/app/lib/dup/indexer.js#L843.

Comme dans Ğ1 dt = 86400 secondes. Il faut donc remplacer 15778800sec par 15778800sec/86400sec = 182,625 jours !